### PR TITLE
Switch to arma_cerr_stream<T>

### DIFF
--- a/src/phylopars_rcpp.cpp
+++ b/src/phylopars_rcpp.cpp
@@ -122,7 +122,7 @@ arma::mat try_inv(arma::mat M,int nvar)
   try
   {
     std::ostream nullstream(0);
-    arma::set_cerr_stream(nullstream);
+    arma::arma_cerr_stream<char>(&nullstream);
     //Minv = pinv(M);
     //M = try_clip(M,nvar,1);
     Minv = inv(M); //Minv = inv(M,"std");
@@ -141,7 +141,7 @@ arma::mat try_solve(arma::mat M,arma::mat V)
   try
   {
     std::ostream nullstream(0);
-    arma::set_cerr_stream(nullstream);
+    arma::arma_cerr_stream<char>(&nullstream);
     //M = try_clip(M,nvar,1);
     Msolve = solve(M,V); //Msolve = solve(M,V,"std");
     //Msolve = pinv(M)*V;
@@ -176,7 +176,7 @@ double logdet(arma::mat A)
   try
   {
     std::ostream nullstream(0);
-    arma::set_cerr_stream(nullstream);
+    arma::arma_cerr_stream<char>(&nullstream);
     log_det(val,sign,A);
     return val;
   }


### PR DESCRIPTION
Armadillo updates its coding convention over time. We have been fairly hard at work to have RcppArmadillo-using packages switch from a now-deprecated older way of instantiatig variables to a newer one (see [issue #391](https://github.com/RcppCore/RcppArmadillo/issues/391) for details; this PR is part of the related [issue #402](https://github.com/RcppCore/RcppArmadillo/issues/402)).

When compiling packages using RcppArmadillo with the deprecation-warning-suppressor we still use, some new warnings come up. One concerns a deprecated way of setting an output or error stream as your package does in three spots in one file. Changing this is fairly straightforward, and affects only that one file.

The package passes its tests with the change as it did before.

It would be much appreciated if you could apply this pull request and update the package at CRAN within the next few months. Let me know if you have any questions.